### PR TITLE
FLCRM-15077 Extract Placemark generating code into separate module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1
+
+- Extracts `placemark`, `geometry` and `extendedData` into standalone functions
+
 ## 0.7.0
 
 - Outputs each `styleHash` with `IconStyle`, `LineStyle` and `PolyStyle` nodes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.7.1
 
 - Extracts `placemark`, `geometry` and `extendedData` into standalone functions
+- Address dependabot issues
 
 ## 0.7.0
 

--- a/index.js
+++ b/index.js
@@ -244,78 +244,11 @@ function data(_) {
   )
 }
 
-// ## Marker style
-function hasMarkerStyle(_) {
-  return !!(_['marker-size'] || _['marker-symbol'] || _['marker-color'])
-}
-
 function removeMarkerStyle(_) {
   delete _['marker-size']
   delete _['marker-symbol']
   delete _['marker-color']
   delete _['marker-shape']
-}
-
-
-function pointStyle(_, styleHash) {
-  const color = tag('color', hexToKmlColor(_['marker-color']) || '7e7e7e')
-  const colorMode = tag('colorMode', 'normal')
-  const icon = tag('Icon', tag('href', iconUrl(_)))
-
-  return tag('IconStyle', color + colorMode + icon)
-}
-
-function markerStyle(_, styleHash) {
-  return tag(
-    'Style',
-    { id: styleHash },
-    tag('IconStyle', tag('Icon', tag('href', iconUrl(_)))) + iconSize(_)
-  )
-}
-
-function iconUrl(_) {
-  var size = _['marker-size'] || 'medium',
-    symbol = _['marker-symbol'] ? '-' + _['marker-symbol'] : '',
-    color = (_['marker-color'] || '7e7e7e').replace('#', '')
-
-  return (
-    'https://api.tiles.mapbox.com/v3/marker/' +
-    'pin-' +
-    size.charAt(0) +
-    symbol +
-    '+' +
-    color +
-    '.png'
-  )
-}
-
-function iconSize(_) {
-  return tag(
-    'hotSpot',
-    {
-      xunits: 'fraction',
-      yunits: 'fraction',
-      x: '0.5',
-      y: '0.5'
-    },
-    ''
-  )
-}
-
-// ## Polygon and Line style
-function hasPolygonAndLineStyle(_) {
-  for (var key in _) {
-    if (
-      {
-        stroke: true,
-        'stroke-opacity': true,
-        'stroke-width': true,
-        fill: true,
-        'fill-opacity': true
-      }[key]
-    )
-      return true
-  }
 }
 
 function removePolygonAndLineStyle(_) {
@@ -324,32 +257,6 @@ function removePolygonAndLineStyle(_) {
   delete _['stroke-width']
   delete _['fill']
   delete _['fill-opacity']
-}
-
-function polygonAndLineStyles(_, styleHash) {
-  var lineStyle = tag(
-    'LineStyle',
-    tag(
-      'color',
-      hexToKmlColor(_['stroke'], _['stroke-opacity']) || 'ff555555'
-    ) +
-      tag('width', {}, _['stroke-width'] === undefined ? 2 : _['stroke-width'])
-  )
-
-  var polyStyle = ''
-
-  if (_['fill'] || _['fill-opacity']) {
-    polyStyle = tag(
-      'PolyStyle',
-      tag(
-        'color',
-        {},
-        hexToKmlColor(_['fill'], _['fill-opacity']) || '88555555'
-      )
-    )
-  }
-
-  return lineStyle + polyStyle
 }
 
 // ## Style helpers
@@ -369,37 +276,6 @@ function hashStyle(_) {
     hash = hash + 'fo' + _['fill-opacity'].toString().replace('.', '')
 
   return hash
-}
-
-function hexToKmlColor(hexColor, opacity) {
-  if (typeof hexColor !== 'string') return ''
-
-  hexColor = hexColor.replace('#', '').toLowerCase()
-
-  if (hexColor.length === 3) {
-    hexColor =
-      hexColor[0] +
-      hexColor[0] +
-      hexColor[1] +
-      hexColor[1] +
-      hexColor[2] +
-      hexColor[2]
-  } else if (hexColor.length !== 6) {
-    return ''
-  }
-
-  var r = hexColor[0] + hexColor[1]
-  var g = hexColor[2] + hexColor[3]
-  var b = hexColor[4] + hexColor[5]
-
-  var o = 'ff'
-  if (typeof opacity === 'number' && opacity >= 0.0 && opacity <= 1.0) {
-    o = (opacity * 255).toString(16)
-    if (o.indexOf('.') > -1) o = o.substr(0, o.indexOf('.'))
-    if (o.length < 2) o = '0' + o
-  }
-
-  return o + b + g + r
 }
 
 // ## General helpers

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function feature(options, styleHashesArray) {
     }
 
     return (
-      styleDefinition + placemark(_, extendeddata, styleHash, options)
+      styleDefinition + placemark(_, styleHash, options, extendeddata)
     )
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,19 +1,13 @@
 const style = require('./lib/style')
 const extendedData = require('./lib/extendedData')
 const geometry = require('./lib/geometry');
-const placemark = require('./lib/placemark')
+const placemark = require('./lib/placemark');
+const defaultOptions = require('./lib/defaultOptions');
 var strxml = require('./lib/strxml'),
   tag = strxml.tag
 
 module.exports = function tokml(geojson, options) {
-  options = options || {
-    documentName: undefined,
-    documentDescription: undefined,
-    name: 'name',
-    description: 'description',
-    simplestyle: false,
-    timestamp: 'timestamp'
-  }
+  options = options || defaultOptions();
 
   return (
     '<?xml version="1.0" encoding="UTF-8"?>' +

--- a/lib/defaultOptions.js
+++ b/lib/defaultOptions.js
@@ -1,0 +1,10 @@
+module.exports = function defaultOptions() {
+  return {
+    documentName: undefined,
+    documentDescription: undefined,
+    name: 'name',
+    description: 'description',
+    simplestyle: false,
+    timestamp: 'timestamp'
+  }
+}

--- a/lib/extendedData.js
+++ b/lib/extendedData.js
@@ -1,0 +1,29 @@
+
+const strxml = require('./strxml');
+const tag = strxml.tag;
+const esc = require('./xml-escape');
+
+module.exports = function extendedData(_) {
+  return tag('ExtendedData', {}, pairs(_).map(data).join(''))
+}
+
+function data(_) {
+  return tag(
+    'Data',
+    { name: _[0] },
+    tag('value', {}, esc(_[1] ? _[1].toString() : ''))
+  )
+}
+
+// ## General helpers
+function pairs(_) {
+  var o = []
+  for (var i in _) {
+    if (_[i]) {
+      o.push([i, _[i]])
+    } else {
+      o.push([i, ''])
+    }
+  }
+  return o
+}

--- a/lib/geometry.js
+++ b/lib/geometry.js
@@ -1,0 +1,100 @@
+const strxml = require('./strxml');
+const tag = strxml.tag;
+
+// https://developers.google.com/kml/documentation/kmlreference#geometry
+const geometry = {
+  Point: function (_) {
+    return tag('Point', tag('coordinates', _.coordinates.join(',')))
+  },
+  LineString: function (_) {
+    return tag('LineString', tag('coordinates', linearring(_.coordinates)))
+  },
+  Polygon: function (_) {
+    if (!_.coordinates.length) return ''
+    var outer = _.coordinates[0],
+      inner = _.coordinates.slice(1),
+      outerRing = tag(
+        'outerBoundaryIs',
+        tag('LinearRing', tag('coordinates', linearring(outer)))
+      ),
+      innerRings = inner
+        .map(function (i) {
+          return tag(
+            'innerBoundaryIs',
+            tag('LinearRing', tag('coordinates', linearring(i)))
+          )
+        })
+        .join('')
+    return tag('Polygon', outerRing + innerRings)
+  },
+  MultiPoint: function (_) {
+    if (!_.coordinates.length) return ''
+    return tag(
+      'MultiGeometry',
+      _.coordinates
+        .map(function (c) {
+          return geometry.Point({ coordinates: c })
+        })
+        .join('')
+    )
+  },
+  MultiPolygon: function (_) {
+    if (!_.coordinates.length) return ''
+    return tag(
+      'MultiGeometry',
+      _.coordinates
+        .map(function (c) {
+          return geometry.Polygon({ coordinates: c })
+        })
+        .join('')
+    )
+  },
+  MultiLineString: function (_) {
+    if (!_.coordinates.length) return ''
+    return tag(
+      'MultiGeometry',
+      _.coordinates
+        .map(function (c) {
+          return geometry.LineString({ coordinates: c })
+        })
+        .join('')
+    )
+  },
+  GeometryCollection: function (_) {
+    return tag('MultiGeometry', _.geometries.map(geometry.any).join(''))
+  },
+  valid: function (_) {
+    return (
+      _ &&
+      _.type &&
+      (_.coordinates ||
+        (_.type === 'GeometryCollection' &&
+          _.geometries &&
+          _.geometries.every(geometry.valid)))
+    )
+  },
+  any: function (_) {
+    if (geometry[_.type]) {
+      return geometry[_.type](_)
+    } else {
+      return ''
+    }
+  },
+  isPoint: function (_) {
+    return _.type === 'Point' || _.type === 'MultiPoint'
+  },
+  isPolygon: function (_) {
+    return _.type === 'Polygon' || _.type === 'MultiPolygon'
+  },
+  isLine: function (_) {
+    return _.type === 'LineString' || _.type === 'MultiLineString'
+  }
+}
+
+function linearring(_) {
+  return _.map(function (cds) {
+    return cds.join(',')
+  }).join(' ')
+}
+
+module.exports = geometry;

--- a/lib/placemark.js
+++ b/lib/placemark.js
@@ -1,3 +1,4 @@
+const defaultOptions = require('./defaultOptions');
 const extendedData = require('./extendedData');
 const geometry = require('./geometry');
 const strxml = require('./strxml');
@@ -5,6 +6,8 @@ const tag = strxml.tag;
 const esc = require('./xml-escape');
 
 module.exports = function placemark(_, styleHash, options, extendeddata) {
+  options = options || defaultOptions();
+
   const id = _.id?.toString();
   const attrs = {};
   if (id) {

--- a/lib/placemark.js
+++ b/lib/placemark.js
@@ -1,15 +1,17 @@
+const extendedData = require('./extendedData');
 const geometry = require('./geometry');
 const strxml = require('./strxml');
 const tag = strxml.tag;
 const esc = require('./xml-escape');
 
-module.exports = function placemark(_, extendeddata, styleHash, options) {
+module.exports = function placemark(_, styleHash, options, extendeddata) {
   const id = _.id?.toString();
   const attrs = {};
-
   if (id) {
     attrs.id = id;
   }
+
+  const data = extendeddata || extendedData(_);
 
   const styleReference = styleHash ? tag('styleUrl', '#' + styleHash) : '';
 
@@ -18,7 +20,7 @@ module.exports = function placemark(_, extendeddata, styleHash, options) {
     attrs, 
     name(_.properties, options) +
       description(_.properties, options) +
-      extendeddata +
+      data +
       timestamp(_.properties, options) +
       geometry.any(_.geometry) +
       styleReference

--- a/lib/placemark.js
+++ b/lib/placemark.js
@@ -1,0 +1,42 @@
+const geometry = require('./geometry');
+const strxml = require('./strxml');
+const tag = strxml.tag;
+const esc = require('./xml-escape');
+
+module.exports = function placemark(_, extendeddata, styleHash, options) {
+  const id = _.id?.toString();
+  const attrs = {};
+
+  if (id) {
+    attrs.id = id;
+  }
+
+  const styleReference = styleHash ? tag('styleUrl', '#' + styleHash) : '';
+
+  return tag(
+    'Placemark', 
+    attrs, 
+    name(_.properties, options) +
+      description(_.properties, options) +
+      extendeddata +
+      timestamp(_.properties, options) +
+      geometry.any(_.geometry) +
+      styleReference
+  )
+}
+
+function name(_, options) {
+  return _[options.name] ? tag('name', esc(_[options.name])) : ''
+}
+
+function description(_, options) {
+  return _[options.description]
+    ? tag('description', esc(_[options.description]))
+    : ''
+}
+
+function timestamp(_, options) {
+  return _[options.timestamp]
+    ? tag('TimeStamp', tag('when', esc(_[options.timestamp])))
+    : ''
+}

--- a/lib/placemark.js
+++ b/lib/placemark.js
@@ -6,7 +6,7 @@ const tag = strxml.tag;
 const esc = require('./xml-escape');
 
 module.exports = function placemark(_, styleHash, options, extendeddata) {
-  options = options || defaultOptions();
+  options = options ?? defaultOptions();
 
   const id = _.id?.toString();
   const attrs = {};
@@ -14,8 +14,7 @@ module.exports = function placemark(_, styleHash, options, extendeddata) {
     attrs.id = id;
   }
 
-  const data = extendeddata || extendedData(_);
-
+  const data = extendeddata ?? extendedData(_.properties);
   const styleReference = styleHash ? tag('styleUrl', '#' + styleHash) : '';
 
   return tag(

--- a/lib/style.js
+++ b/lib/style.js
@@ -1,10 +1,13 @@
-var strxml = require('./strxml'),
-  tag = strxml.tag
+const defaultOptions = require('./defaultOptions');
+const strxml = require('./strxml')
+const tag = strxml.tag
 
 const defaultPointColor = '7e7e7e';
 const defaultPolyAndLineColor = '555555'
 
 module.exports = function style(_, styleHash, options) {
+  options = options || defaultOptions();
+
   const points = pointStyle(_, options);
   const polysAndLines = polygonAndLineStyles(_);
   const hotSpot = iconSize(_);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fulcrumapp/tokml",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "convert geojson to kml",
   "main": "index.js",
   "scripts": {

--- a/tokml.js
+++ b/tokml.js
@@ -2,19 +2,13 @@
 const style = require('./lib/style')
 const extendedData = require('./lib/extendedData')
 const geometry = require('./lib/geometry');
-const placemark = require('./lib/placemark')
+const placemark = require('./lib/placemark');
+const defaultOptions = require('./lib/defaultOptions');
 var strxml = require('./lib/strxml'),
   tag = strxml.tag
 
 module.exports = function tokml(geojson, options) {
-  options = options || {
-    documentName: undefined,
-    documentDescription: undefined,
-    name: 'name',
-    description: 'description',
-    simplestyle: false,
-    timestamp: 'timestamp'
-  }
+  options = options || defaultOptions();
 
   return (
     '<?xml version="1.0" encoding="UTF-8"?>' +
@@ -64,7 +58,7 @@ function feature(options, styleHashesArray) {
     }
 
     return (
-      styleDefinition + placemark(_, extendeddata, styleHash, options)
+      styleDefinition + placemark(_, styleHash, options, extendeddata)
     )
   }
 }
@@ -137,7 +131,18 @@ function hashStyle(_) {
   return hash
 }
 
-},{"./lib/extendedData":2,"./lib/geometry":3,"./lib/placemark":4,"./lib/strxml":5,"./lib/style":6}],2:[function(require,module,exports){
+},{"./lib/defaultOptions":2,"./lib/extendedData":3,"./lib/geometry":4,"./lib/placemark":5,"./lib/strxml":6,"./lib/style":7}],2:[function(require,module,exports){
+module.exports = function defaultOptions() {
+  return {
+    documentName: undefined,
+    documentDescription: undefined,
+    name: 'name',
+    description: 'description',
+    simplestyle: false,
+    timestamp: 'timestamp'
+  }
+}
+},{}],3:[function(require,module,exports){
 
 const strxml = require('./strxml');
 const tag = strxml.tag;
@@ -168,7 +173,7 @@ function pairs(_) {
   return o
 }
 
-},{"./strxml":5,"./xml-escape":7}],3:[function(require,module,exports){
+},{"./strxml":6,"./xml-escape":8}],4:[function(require,module,exports){
 const strxml = require('./strxml');
 const tag = strxml.tag;
 
@@ -269,20 +274,24 @@ function linearring(_) {
 }
 
 module.exports = geometry;
-},{"./strxml":5}],4:[function(require,module,exports){
+},{"./strxml":6}],5:[function(require,module,exports){
+const defaultOptions = require('./defaultOptions');
+const extendedData = require('./extendedData');
 const geometry = require('./geometry');
 const strxml = require('./strxml');
 const tag = strxml.tag;
 const esc = require('./xml-escape');
 
-module.exports = function placemark(_, extendeddata, styleHash, options) {
+module.exports = function placemark(_, styleHash, options, extendeddata) {
+  options = options ?? defaultOptions();
+
   const id = _.id?.toString();
   const attrs = {};
-
   if (id) {
     attrs.id = id;
   }
 
+  const data = extendeddata ?? extendedData(_.properties);
   const styleReference = styleHash ? tag('styleUrl', '#' + styleHash) : '';
 
   return tag(
@@ -290,7 +299,7 @@ module.exports = function placemark(_, extendeddata, styleHash, options) {
     attrs, 
     name(_.properties, options) +
       description(_.properties, options) +
-      extendeddata +
+      data +
       timestamp(_.properties, options) +
       geometry.any(_.geometry) +
       styleReference
@@ -313,7 +322,7 @@ function timestamp(_, options) {
     : ''
 }
 
-},{"./geometry":3,"./strxml":5,"./xml-escape":7}],5:[function(require,module,exports){
+},{"./defaultOptions":2,"./extendedData":3,"./geometry":4,"./strxml":6,"./xml-escape":8}],6:[function(require,module,exports){
 /* istanbul ignore file */
 // strxml from https://github.com/mapbox/strxml
 
@@ -371,14 +380,17 @@ function tag(el, attributes, contents) {
   return '<' + el + attr(attributes) + '>' + contents + '</' + el + '>'
 }
 
-},{"./xml-escape":7}],6:[function(require,module,exports){
-var strxml = require('./strxml'),
-  tag = strxml.tag
+},{"./xml-escape":8}],7:[function(require,module,exports){
+const defaultOptions = require('./defaultOptions');
+const strxml = require('./strxml')
+const tag = strxml.tag
 
 const defaultPointColor = '7e7e7e';
 const defaultPolyAndLineColor = '555555'
 
 module.exports = function style(_, styleHash, options) {
+  options = options || defaultOptions();
+
   const points = pointStyle(_, options);
   const polysAndLines = polygonAndLineStyles(_);
   const hotSpot = iconSize(_);
@@ -507,7 +519,7 @@ function legacyIconUrl(_) {
   )
 }
 
-},{"./strxml":5}],7:[function(require,module,exports){
+},{"./defaultOptions":2,"./strxml":6}],8:[function(require,module,exports){
 /* istanbul ignore file */
 // originally from https://github.com/miketheprogrammer/xml-escape
 

--- a/tokml.js
+++ b/tokml.js
@@ -1,5 +1,8 @@
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.tokml = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
-var esc = require('./lib/xml-escape')
+const style = require('./lib/style')
+const extendedData = require('./lib/extendedData')
+const geometry = require('./lib/geometry');
+const placemark = require('./lib/placemark')
 var strxml = require('./lib/strxml'),
   tag = strxml.tag
 
@@ -30,51 +33,38 @@ module.exports = function tokml(geojson, options) {
 
 function feature(options, styleHashesArray) {
   return function (_) {
-    if (!_.properties || !geometry.valid(_.geometry)) return ''
-    var geometryString = geometry.any(_.geometry)
-    if (!geometryString) return ''
+    if (!_.properties || !geometry.valid(_.geometry) || !geometry.any(_.geometry)) return ''
 
-    var styleDefinition = '',
-      styleReference = ''
+    let styleDefinition = '';
+
+    let extendeddata;
+    if (_.geometry?.type === 'GeometryCollection') {
+      extendeddata = extendedData(_.properties);
+    }
+
     if (options.simplestyle) {
       var styleHash = hashStyle(_.properties)
       if (styleHash) {
-        if (geometry.isPoint(_.geometry) && hasMarkerStyle(_.properties)) {
-          if (styleHashesArray.indexOf(styleHash) === -1) {
-            styleDefinition = markerStyle(_.properties, styleHash)
-            styleHashesArray.push(styleHash)
-          }
-          styleReference = tag('styleUrl', '#' + styleHash)
-          removeMarkerStyle(_.properties)
-        } else if (
-          (geometry.isPolygon(_.geometry) || geometry.isLine(_.geometry)) &&
-          hasPolygonAndLineStyle(_.properties)
-        ) {
-          if (styleHashesArray.indexOf(styleHash) === -1) {
-            styleDefinition = polygonAndLineStyle(_.properties, styleHash)
-            styleHashesArray.push(styleHash)
-          }
-          styleReference = tag('styleUrl', '#' + styleHash)
-          removePolygonAndLineStyle(_.properties)
+
+        const styleTag = style(_.properties, styleHash, options);
+
+        if (styleHashesArray.indexOf(styleHash) === -1) {
+          styleHashesArray.push(styleHash);
+          styleDefinition = styleTag;
         }
+
+        removeMarkerStyle(_.properties);
+        removePolygonAndLineStyle(_.properties);
         // Note that style of GeometryCollection / MultiGeometry is not supported
       }
     }
 
-    var attributes = {}
-    if (_.id) attributes.id = _.id.toString();
+    if (!extendeddata) {
+      extendeddata = extendedData(_.properties);
+    }
+
     return (
-      styleDefinition +
-      tag(
-        'Placemark',
-        attributes,
-        name(_.properties, options) +
-          description(_.properties, options) +
-          extendeddata(_.properties) +
-          timestamp(_.properties, options) +
-          geometryString +
-          styleReference
-      )
+      styleDefinition + placemark(_, extendeddata, styleHash, options)
     )
   }
 }
@@ -113,26 +103,77 @@ function documentDescription(options) {
     : ''
 }
 
-function name(_, options) {
-  return _[options.name] ? tag('name', esc(_[options.name])) : ''
+function removeMarkerStyle(_) {
+  delete _['marker-size']
+  delete _['marker-symbol']
+  delete _['marker-color']
+  delete _['marker-shape']
 }
 
-function description(_, options) {
-  return _[options.description]
-    ? tag('description', esc(_[options.description]))
-    : ''
+function removePolygonAndLineStyle(_) {
+  delete _['stroke']
+  delete _['stroke-opacity']
+  delete _['stroke-width']
+  delete _['fill']
+  delete _['fill-opacity']
 }
 
-function timestamp(_, options) {
-  return _[options.timestamp]
-    ? tag('TimeStamp', tag('when', esc(_[options.timestamp])))
-    : ''
+// ## Style helpers
+function hashStyle(_) {
+  var hash = ''
+
+  if (_['marker-symbol']) hash = hash + 'ms' + _['marker-symbol']
+  if (_['marker-color']) hash = hash + 'mc' + _['marker-color'].replace('#', '')
+  if (_['marker-size']) hash = hash + 'ms' + _['marker-size']
+  if (_['stroke']) hash = hash + 's' + _['stroke'].replace('#', '')
+  if (_['stroke-width'])
+    hash = hash + 'sw' + _['stroke-width'].toString().replace('.', '')
+  if (_['stroke-opacity'])
+    hash = hash + 'mo' + _['stroke-opacity'].toString().replace('.', '')
+  if (_['fill']) hash = hash + 'f' + _['fill'].replace('#', '')
+  if (_['fill-opacity'])
+    hash = hash + 'fo' + _['fill-opacity'].toString().replace('.', '')
+
+  return hash
 }
 
-// ## Geometry Types
-//
+},{"./lib/extendedData":2,"./lib/geometry":3,"./lib/placemark":4,"./lib/strxml":5,"./lib/style":6}],2:[function(require,module,exports){
+
+const strxml = require('./strxml');
+const tag = strxml.tag;
+const esc = require('./xml-escape');
+
+module.exports = function extendedData(_) {
+  return tag('ExtendedData', {}, pairs(_).map(data).join(''))
+}
+
+function data(_) {
+  return tag(
+    'Data',
+    { name: _[0] },
+    tag('value', {}, esc(_[1] ? _[1].toString() : ''))
+  )
+}
+
+// ## General helpers
+function pairs(_) {
+  var o = []
+  for (var i in _) {
+    if (_[i]) {
+      o.push([i, _[i]])
+    } else {
+      o.push([i, ''])
+    }
+  }
+  return o
+}
+
+},{"./strxml":5,"./xml-escape":7}],3:[function(require,module,exports){
+const strxml = require('./strxml');
+const tag = strxml.tag;
+
 // https://developers.google.com/kml/documentation/kmlreference#geometry
-var geometry = {
+const geometry = {
   Point: function (_) {
     return tag('Point', tag('coordinates', _.coordinates.join(',')))
   },
@@ -227,182 +268,52 @@ function linearring(_) {
   }).join(' ')
 }
 
-// ## Data
-function extendeddata(_) {
-  return tag('ExtendedData', {}, pairs(_).map(data).join(''))
-}
+module.exports = geometry;
+},{"./strxml":5}],4:[function(require,module,exports){
+const geometry = require('./geometry');
+const strxml = require('./strxml');
+const tag = strxml.tag;
+const esc = require('./xml-escape');
 
-function data(_) {
+module.exports = function placemark(_, extendeddata, styleHash, options) {
+  const id = _.id?.toString();
+  const attrs = {};
+
+  if (id) {
+    attrs.id = id;
+  }
+
+  const styleReference = styleHash ? tag('styleUrl', '#' + styleHash) : '';
+
   return tag(
-    'Data',
-    { name: _[0] },
-    tag('value', {}, esc(_[1] ? _[1].toString() : ''))
+    'Placemark', 
+    attrs, 
+    name(_.properties, options) +
+      description(_.properties, options) +
+      extendeddata +
+      timestamp(_.properties, options) +
+      geometry.any(_.geometry) +
+      styleReference
   )
 }
 
-// ## Marker style
-function hasMarkerStyle(_) {
-  return !!(_['marker-size'] || _['marker-symbol'] || _['marker-color'])
+function name(_, options) {
+  return _[options.name] ? tag('name', esc(_[options.name])) : ''
 }
 
-function removeMarkerStyle(_) {
-  delete _['marker-size']
-  delete _['marker-symbol']
-  delete _['marker-color']
-  delete _['marker-shape']
+function description(_, options) {
+  return _[options.description]
+    ? tag('description', esc(_[options.description]))
+    : ''
 }
 
-function markerStyle(_, styleHash) {
-  return tag(
-    'Style',
-    { id: styleHash },
-    tag('IconStyle', tag('Icon', tag('href', iconUrl(_)))) + iconSize(_)
-  )
+function timestamp(_, options) {
+  return _[options.timestamp]
+    ? tag('TimeStamp', tag('when', esc(_[options.timestamp])))
+    : ''
 }
 
-function iconUrl(_) {
-  var size = _['marker-size'] || 'medium',
-    symbol = _['marker-symbol'] ? '-' + _['marker-symbol'] : '',
-    color = (_['marker-color'] || '7e7e7e').replace('#', '')
-
-  return (
-    'https://api.tiles.mapbox.com/v3/marker/' +
-    'pin-' +
-    size.charAt(0) +
-    symbol +
-    '+' +
-    color +
-    '.png'
-  )
-}
-
-function iconSize(_) {
-  return tag(
-    'hotSpot',
-    {
-      xunits: 'fraction',
-      yunits: 'fraction',
-      x: '0.5',
-      y: '0.5'
-    },
-    ''
-  )
-}
-
-// ## Polygon and Line style
-function hasPolygonAndLineStyle(_) {
-  for (var key in _) {
-    if (
-      {
-        stroke: true,
-        'stroke-opacity': true,
-        'stroke-width': true,
-        fill: true,
-        'fill-opacity': true
-      }[key]
-    )
-      return true
-  }
-}
-
-function removePolygonAndLineStyle(_) {
-  delete _['stroke']
-  delete _['stroke-opacity']
-  delete _['stroke-width']
-  delete _['fill']
-  delete _['fill-opacity']
-}
-
-function polygonAndLineStyle(_, styleHash) {
-  var lineStyle = tag(
-    'LineStyle',
-    tag(
-      'color',
-      hexToKmlColor(_['stroke'], _['stroke-opacity']) || 'ff555555'
-    ) +
-      tag('width', {}, _['stroke-width'] === undefined ? 2 : _['stroke-width'])
-  )
-
-  var polyStyle = ''
-
-  if (_['fill'] || _['fill-opacity']) {
-    polyStyle = tag(
-      'PolyStyle',
-      tag(
-        'color',
-        {},
-        hexToKmlColor(_['fill'], _['fill-opacity']) || '88555555'
-      )
-    )
-  }
-
-  return tag('Style', { id: styleHash }, lineStyle + polyStyle)
-}
-
-// ## Style helpers
-function hashStyle(_) {
-  var hash = ''
-
-  if (_['marker-symbol']) hash = hash + 'ms' + _['marker-symbol']
-  if (_['marker-color']) hash = hash + 'mc' + _['marker-color'].replace('#', '')
-  if (_['marker-size']) hash = hash + 'ms' + _['marker-size']
-  if (_['stroke']) hash = hash + 's' + _['stroke'].replace('#', '')
-  if (_['stroke-width'])
-    hash = hash + 'sw' + _['stroke-width'].toString().replace('.', '')
-  if (_['stroke-opacity'])
-    hash = hash + 'mo' + _['stroke-opacity'].toString().replace('.', '')
-  if (_['fill']) hash = hash + 'f' + _['fill'].replace('#', '')
-  if (_['fill-opacity'])
-    hash = hash + 'fo' + _['fill-opacity'].toString().replace('.', '')
-
-  return hash
-}
-
-function hexToKmlColor(hexColor, opacity) {
-  if (typeof hexColor !== 'string') return ''
-
-  hexColor = hexColor.replace('#', '').toLowerCase()
-
-  if (hexColor.length === 3) {
-    hexColor =
-      hexColor[0] +
-      hexColor[0] +
-      hexColor[1] +
-      hexColor[1] +
-      hexColor[2] +
-      hexColor[2]
-  } else if (hexColor.length !== 6) {
-    return ''
-  }
-
-  var r = hexColor[0] + hexColor[1]
-  var g = hexColor[2] + hexColor[3]
-  var b = hexColor[4] + hexColor[5]
-
-  var o = 'ff'
-  if (typeof opacity === 'number' && opacity >= 0.0 && opacity <= 1.0) {
-    o = (opacity * 255).toString(16)
-    if (o.indexOf('.') > -1) o = o.substr(0, o.indexOf('.'))
-    if (o.length < 2) o = '0' + o
-  }
-
-  return o + b + g + r
-}
-
-// ## General helpers
-function pairs(_) {
-  var o = []
-  for (var i in _) {
-    if (_[i]) {
-      o.push([i, _[i]])
-    } else {
-      o.push([i, ''])
-    }
-  }
-  return o
-}
-
-},{"./lib/strxml":2,"./lib/xml-escape":3}],2:[function(require,module,exports){
+},{"./geometry":3,"./strxml":5,"./xml-escape":7}],5:[function(require,module,exports){
 /* istanbul ignore file */
 // strxml from https://github.com/mapbox/strxml
 
@@ -460,7 +371,143 @@ function tag(el, attributes, contents) {
   return '<' + el + attr(attributes) + '>' + contents + '</' + el + '>'
 }
 
-},{"./xml-escape":3}],3:[function(require,module,exports){
+},{"./xml-escape":7}],6:[function(require,module,exports){
+var strxml = require('./strxml'),
+  tag = strxml.tag
+
+const defaultPointColor = '7e7e7e';
+const defaultPolyAndLineColor = '555555'
+
+module.exports = function style(_, styleHash, options) {
+  const points = pointStyle(_, options);
+  const polysAndLines = polygonAndLineStyles(_);
+  const hotSpot = iconSize(_);
+
+  return tag('Style', { id: styleHash}, points + polysAndLines + hotSpot);
+}
+
+function currentColor(_) {
+  let markerColor = hexToKmlColor(_['marker-color']) || currentPolyColor(_) || currentLineColor(_);
+
+  return markerColor || forceOpacity(defaultPointColor, 'ff');
+}
+
+function currentColorRawValue(_) {
+  return _['marker-color'] || _['fill'] || _['stroke'] || defaultPointColor;
+}
+
+function currentLineColor(_) {
+  return hexToKmlColor(_['stroke'], _['stroke-opacity'])
+}
+
+function currentPolyColor(_) {
+  return hexToKmlColor(_['fill'], _['fill-opacity'])
+}
+
+function newColorModeTag() {
+  return tag('colorMode', 'normal')
+}
+
+function pointStyle(_, options) {
+  const color = tag('color', forceOpacity(currentColor(_), 'ff'))
+  const colorMode = newColorModeTag();
+  const icon = tag('Icon', tag('href', iconUrl(_, options)))
+
+  return tag('IconStyle', color + colorMode + icon)
+}
+
+function forceOpacity(color, opacity) {
+  return opacity + color.slice(-6);
+}
+
+function polygonAndLineStyles(_) {
+  const color = currentColor(_);
+  let lineColor = color;
+  let lineWidth = _['stroke-width'] === undefined ? 2 : _['stroke-width'];
+  let polyColor = forceOpacity(color, '88');
+
+  if (_['stroke' || _['stroke-opacity']]) {
+    lineColor = currentLineColor(_) || forceOpacity(defaultPolyAndLineColor, 'ff');
+  }
+
+  if (_['fill'] || _['fill-opacity']) {
+    polyColor = currentPolyColor(_)  || forceOpacity(defaultPolyAndLineColor, '88')
+  }
+
+  const widthTag = tag('width', String(lineWidth));
+  const lineColorTag = tag('color', lineColor);
+  const polyTag = tag('color', polyColor);
+  const lineStyle = tag('LineStyle', lineColorTag + newColorModeTag() + widthTag);
+  const polyStyle = tag('PolyStyle', polyTag + newColorModeTag());
+
+  return lineStyle + polyStyle
+}
+
+function iconSize(_) {
+  return tag(
+    'hotSpot',
+    {
+      xunits: 'fraction',
+      yunits: 'fraction',
+      x: '0.5',
+      y: '0.5'
+    },
+    ''
+  )
+}
+
+function hexToKmlColor(hexColor, opacity) {
+  if (typeof hexColor !== 'string') return ''
+
+  hexColor = hexColor.replace('#', '').toLowerCase()
+
+  if (hexColor.length === 3) {
+    hexColor =
+      hexColor[0] +
+      hexColor[0] +
+      hexColor[1] +
+      hexColor[1] +
+      hexColor[2] +
+      hexColor[2]
+  } else if (hexColor.length !== 6) {
+    return ''
+  }
+
+  var r = hexColor[0] + hexColor[1]
+  var g = hexColor[2] + hexColor[3]
+  var b = hexColor[4] + hexColor[5]
+
+  var o = 'ff'
+  if (typeof opacity === 'number' && opacity >= 0.0 && opacity <= 1.0) {
+    o = (opacity * 255).toString(16)
+    if (o.indexOf('.') > -1) o = o.substr(0, o.indexOf('.'))
+    if (o.length < 2) o = '0' + o
+  }
+
+  return o + b + g + r
+}
+
+function iconUrl(_, options) {
+  return options?.iconUrl ?? legacyIconUrl(_)
+}
+
+function legacyIconUrl(_) {
+  var size = _['marker-size'] || 'medium',
+    symbol = _['marker-symbol'] ? '-' + _['marker-symbol'] : '',
+    color = (currentColorRawValue(_) || defaultPointColor).replace('#', '')
+
+  return (
+    'https://api.tiles.mapbox.com/v3/marker/' +
+    'pin-' +
+    size.charAt(0) +
+    symbol +
+    '+' +
+    color +
+    '.png'
+  )
+}
+
+},{"./strxml":5}],7:[function(require,module,exports){
 /* istanbul ignore file */
 // originally from https://github.com/miketheprogrammer/xml-escape
 


### PR DESCRIPTION
This PR refactors the code to expose some of the functionality as exported modules. This is potentially useful for converting non-GeoJSON payloads into KML that matches what `tokml` provides

Relates to Fulcrum issue [FLCRM-15077](https://fulcrumapp.atlassian.net/browse/FLCRM-15077)

Testing in Fulcrum
- Shared Views
  - Create a Form with Records with advanced geometry and a variety of Status colors
  - Create a Shared View of all Records (no filters)
  - Use the "KML" tab to obtain the URL of the share
  - Note that putting the url into your browser, then renaming the file to have a .kml extension works better in most tools than using the URL directly. Google Earth only accepts files, while ArcGIS MapViewer only accepts a URL.
- Data Downloader
  - With the same Form, open the DataViewer and zoom out until all Records are within the view
  - Use the Download Data function to output KML
  - The output should match the Shared View output

From the preview environment:

![Screenshot 2024-05-14 at 4 44 13 PM](https://github.com/fulcrumapp/tokml/assets/2982313/271bb054-08b7-4dab-adee-d47ee7de7328)


Here are KML files, one from the Shared View and one from the Data Download, imported into Google Earth:

https://github.com/fulcrumapp/tokml/assets/2982313/6200cc68-23d4-46e0-a531-ce78d94fbbd9


[FLCRM-15077]: https://fulcrumapp.atlassian.net/browse/FLCRM-15077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ